### PR TITLE
feat: make plugin working together with serverless-plugin-stage-variables when API GW logs are enabled

### DIFF
--- a/test/support/ServerlessBuilder.ts
+++ b/test/support/ServerlessBuilder.ts
@@ -48,7 +48,9 @@ export class ServerlessBuilder {
           Resources: {
             EsLogsProcesserLambdaFunction: {
               DependsOn: [],
-              Properties: {},
+              Properties: {
+                FunctionName: 'functionName',
+              },
             },
             IamRoleLambdaExecution: {
               DependsOn: [],


### PR DESCRIPTION
see https://github.com/daniel-cottone/serverless-es-logs/issues/197

I have not checked if it still works with alias plugin, but I doubt I has been working before, because there was a bug in Line 162