### PR TITLE
feat(api-gw-logging): Support serverless native API GW logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,17 @@ custom:
 
 #### includeApiGWLogs
 
-(Optional) An option to be used in conjunction with the [serverless-aws-alias](https://github.com/HyperBrain/serverless-aws-alias) plugin. This will capture logs created by API Gateway and transport them to Elasticsearch.
+(Optional) An option to capture logs created by API Gateway and transport them to Elasticsearch.
 
 ```yaml
 custom:
   esLogs:
     includeApiGWLogs: true
+
+provider:
+  name: aws
+  logs:
+    restApi: true
 ```
 
 #### index
@@ -117,8 +122,8 @@ custom:
     useDefaultRole: true
 
 provider:
-    name: aws
-    role: arn:aws:iam::123456789012:role/MyCustomRole
+  name: aws
+  role: arn:aws:iam::123456789012:role/MyCustomRole
 ```
 
 [sls-image]:http://public.serverless.com/badges/v3.svg

--- a/test/support/ServerlessBuilder.ts
+++ b/test/support/ServerlessBuilder.ts
@@ -29,26 +29,18 @@ export class ServerlessBuilder {
         return Object.keys(this.serverless.service.functions);
       },
       provider: {
-        compiledCloudFormationAliasTemplate: {
+        compiledCloudFormationTemplate: {
           Resources: {
-            ApiGatewayStage: {
+            ApiGatewayLogGroup: {
               Properties: {
-                RestApiId: 'restApiId',
-                StageName: 'stageName',
+                LogGroupName: 'log-group-name',
               },
             },
-            EsLogsProcesserAlias: {
+            EsLogsProcesserLambdaFunction: {
+              DependsOn: [],
               Properties: {
                 FunctionName: 'functionName',
               },
-            },
-          },
-        },
-        compiledCloudFormationTemplate: {
-          Resources: {
-            EsLogsProcesserLambdaFunction: {
-              DependsOn: [],
-              Properties: {},
             },
             IamRoleLambdaExecution: {
               DependsOn: [],

--- a/test/unit/plugin.test.ts
+++ b/test/unit/plugin.test.ts
@@ -212,7 +212,7 @@ describe('serverless-es-logs :: Plugin tests', () => {
         }]);
       });
 
-      describe('#addCloudwatchSubscriptions()', () => {
+      describe('#addLambdaCloudwatchSubscriptions()', () => {
         it('shouldn\'t add any subscriptions or permissions if there are no functions', () => {
           const template = serverless.service.provider.compiledCloudFormationTemplate;
           plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
@@ -258,17 +258,11 @@ describe('serverless-es-logs :: Plugin tests', () => {
           expect(logGroups.length).to.equal(numFunctions);
         });
       });
-    });
-
-    describe('before:aws:deploy:deploy:updateStack', () => {
-      it('should exist', () => {
-        expect(plugin.hooks['before:aws:deploy:deploy:updateStack']).to.exist;
-      });
 
       describe('#addApiGwCloudwatchSubscription()', () => {
         it('should skip if \'includeApiGWLogs\' option not set', () => {
-          const template = serverless.service.provider.compiledCloudFormationAliasTemplate;
-          plugin.hooks['before:aws:deploy:deploy:updateStack']();
+          const template = serverless.service.provider.compiledCloudFormationTemplate;
+          plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
           const subscriptions = _.filter(template.Resources, (v, k) => v.Type === 'AWS::Logs::SubscriptionFilter');
           const permissions = _.filter(template.Resources, (v, k) => v.Type === 'AWS::Lambda::Permission');
           expect(subscriptions.length).to.equal(0);
@@ -278,8 +272,8 @@ describe('serverless-es-logs :: Plugin tests', () => {
         it('should create a subscription and permission for API Gateway logs', () => {
           serverless.service.custom.esLogs.includeApiGWLogs = true;
           plugin = new ServerlessEsLogsPlugin(serverless, options);
-          const template = serverless.service.provider.compiledCloudFormationAliasTemplate;
-          plugin.hooks['before:aws:deploy:deploy:updateStack']();
+          const template = serverless.service.provider.compiledCloudFormationTemplate;
+          plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
           const subscriptions = _.filter(template.Resources, (v, k) => v.Type === 'AWS::Logs::SubscriptionFilter');
           const permissions = _.filter(template.Resources, (v, k) => v.Type === 'AWS::Lambda::Permission');
           expect(subscriptions.length).to.equal(1);


### PR DESCRIPTION
BREAKING CHANGE: Removing support for serverless-aws-alias plugin
This plugin is not being maintained. Furthermore, API Gateway logging
is now supported in serverless framework.