### PR TITLE
Add aws permissions for api gateway tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ provider:
   role: arn:aws:iam::123456789012:role/MyCustomRole
 ```
 
+#### xrayTracingPermissions
+
+(Optional) Adds AWS Xray writing permissions to the processor lambda. You will need these if you enable tracing for ApiGateway on your service. 
+
+```yaml
+custom:
+  esLogs:
+    xrayTracingPermissions: true
+
+provider:
+  tracing:
+    apiGateway: true
+```
+
 [sls-image]:http://public.serverless.com/badges/v3.svg
 [sls-url]:http://www.serverless.com
 [npm-image]:https://img.shields.io/npm/v/serverless-es-logs.svg

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-es-logs",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "license": "MIT",
   "description": "A Serverless plugin to transport logs to ElasticSearch",
   "author": "Daniel Cottone <daniel.cottone@asurion.com> (https://github.com/daniel-cottone)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { LambdaPermissionBuilder, SubscriptionFilterBuilder, TemplateBuilder } f
 // tslint:disable:no-var-requires
 const iamLambdaTemplate = require('../templates/iam/lambda-role.json');
 // tslint:enable:no-var-requires
+const withXrayTracingPermissions = require('../templates/iam/withXrayTracingPermissions.js');
 
 class ServerlessEsLogsPlugin {
   public hooks: { [name: string]: () => void };
@@ -57,7 +58,7 @@ class ServerlessEsLogsPlugin {
 
   private mergeCustomProviderResources(): void {
     this.serverless.cli.log('ServerlessEsLogsPlugin.mergeCustomProviderResources()');
-    const { includeApiGWLogs, retentionInDays, useDefaultRole } = this.custom().esLogs;
+    const { includeApiGWLogs, retentionInDays, useDefaultRole, xrayTracingPermissions } = this.custom().esLogs;
     const template = this.serverless.service.provider.compiledCloudFormationTemplate;
 
     // Add cloudwatch subscriptions to firehose for functions' log groups
@@ -66,6 +67,12 @@ class ServerlessEsLogsPlugin {
     // Configure Cloudwatch log retention
     if (retentionInDays !== undefined) {
       this.configureLogRetention(retentionInDays);
+    }
+
+    // Add xray permissions if option is enabled
+    if (xrayTracingPermissions === true) {
+      const statement = iamLambdaTemplate.ServerlessEsLogsLambdaIAMRole.Properties.Policies[0].PolicyDocument.Statement;
+      statement.push(withXrayTracingPermissions);
     }
 
     // Add IAM role for cloudwatch -> elasticsearch lambda

--- a/templates/iam/withXrayTracingPermissions.js
+++ b/templates/iam/withXrayTracingPermissions.js
@@ -1,0 +1,11 @@
+module.exports = {
+  Effect: "Allow",
+  Action: [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+      "xray:GetSamplingRules",
+      "xray:GetSamplingTargets",
+      "xray:GetSamplingStatisticSummaries"
+  ],
+  Resource: "*"
+}

--- a/test/unit/plugin.test.ts
+++ b/test/unit/plugin.test.ts
@@ -212,6 +212,57 @@ describe('serverless-es-logs :: Plugin tests', () => {
         }]);
       });
 
+      it('should append xray permissions policy to generated role if option is enabled and no default role specified', () => {
+        const template = serverless.service.provider.compiledCloudFormationTemplate;
+        serverless.service.custom.esLogs.xrayTracingPermissions = true;
+        plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
+        expect(template.Resources).to.have.property('IamRoleLambdaExecution');
+        expect(template.Resources.IamRoleLambdaExecution.Properties.Policies).to.have.deep.members([{
+          PolicyDocument: {
+            Statement: [
+              {
+                Action: [
+                  'logs:CreateLogGroup',
+                  'logs:CreateLogStream',
+                  'logs:PutLogEvents',
+                ],
+                Effect: 'Allow',
+                Resource: 'arn:aws:logs:*:*:*',
+              },
+              {
+                Action: 'es:ESHttpPost',
+                Effect: 'Allow',
+                Resource: {
+                  'Fn::Sub': 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*',
+                },
+              },
+              {
+                Action: [
+                  'ec2:CreateNetworkInterface',
+                  'ec2:DescribeNetworkInterfaces',
+                  'ec2:DeleteNetworkInterface',
+                ],
+                Effect: 'Allow',
+                Resource: '*',
+              },
+              {
+                Action: [
+                    "xray:PutTraceSegments",
+                    "xray:PutTelemetryRecords",
+                    "xray:GetSamplingRules",
+                    "xray:GetSamplingTargets",
+                    "xray:GetSamplingStatisticSummaries"
+                ],
+                Effect: "Allow",
+                Resource: "*"
+              }
+            ],
+            Version: '2012-10-17',
+          },
+          PolicyName: 'cw-to-elasticsearch-policy',
+        }]);
+      });
+
       describe('#addLambdaCloudwatchSubscriptions()', () => {
         it('shouldn\'t add any subscriptions or permissions if there are no functions', () => {
           const template = serverless.service.provider.compiledCloudFormationTemplate;


### PR DESCRIPTION
Adds option to give the processor Lamda Xray write permissions. Without these you will get deployment failures if you try to enable tracing for ApiGateway on your service.