### PR TITLE
Node.js 8.10 is EOL, migrating functions generatations to a newer version

### DIFF
--- a/examples/rest-api/serverless.yml
+++ b/examples/rest-api/serverless.yml
@@ -11,7 +11,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   logs:
     restApi: true
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,7 +283,7 @@ class ServerlessEsLogsPlugin {
         include: [`${this.logProcesserDir}/**`],
         individually: true,
       },
-      runtime: 'nodejs8.10',
+      runtime: 'nodejs10.x',
       timeout: 60,
       tracing: false,
     };

--- a/test/support/ServerlessBuilder.ts
+++ b/test/support/ServerlessBuilder.ts
@@ -52,7 +52,7 @@ export class ServerlessBuilder {
         },
         name: 'aws',
         region: 'us-east-1',
-        runtime: 'nodejs8.10',
+        runtime: 'nodejs10.x',
         stage: 'dev',
       },
     },


### PR DESCRIPTION
@daniel-cottone as you might be aware AWS Lambdas at 8.10 are at EOL in Jan 2020 