### PR TITLE
feat: Support custom separator for date format of index

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ custom:
     index: some-index
 ```
 
+#### indexDateSeparator
+
+(Optional) The separator to use when creating the date suffix for the index. Default is `.`.
+
+The format of the index will be: `<index>-YYYY<indexDateSeparator>MM<indexDateSeparator>DD`
+
+```yaml
+custom:
+  esLogs:
+    indexDateSeparator: '-'
+```
+
+This will result in a date like `2020-04-20`.
+
 #### retentionInDays
 
 (Optional) The number of days that Cloudwatch logs should persist. Default is to never expire.
@@ -164,7 +178,7 @@ custom:
 
 #### xrayTracingPermissions
 
-(Optional) Adds AWS Xray writing permissions to the processor lambda. You will need these if you enable tracing for ApiGateway on your service. 
+(Optional) Adds AWS Xray writing permissions to the processor lambda. You will need these if you enable tracing for ApiGateway on your service.
 
 ```yaml
 custom:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ custom:
 
 #### xrayTracingPermissions
 
-(Optional) Adds AWS Xray writing permissions to the processor lambda. You will need these if you enable tracing for ApiGateway on your service.
+(Optional) Adds AWS Xray writing permissions to the processor lambda. You will need these if you enable tracing for ApiGateway on your service. 
 
 ```yaml
 custom:

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ class ServerlessEsLogsPlugin {
             ],
           ],
         })
-        .withDependsOn([this.logProcesserLogicalId, apiGwLogGroupLogicalId])
+        .withDependsOn([ this.logProcesserLogicalId, apiGwLogGroupLogicalId ])
         .build();
 
       // Create subscription filter
@@ -180,7 +180,7 @@ class ServerlessEsLogsPlugin {
         })
         .withFilterPattern(filterPattern)
         .withLogGroupName(LogGroupName)
-        .withDependsOn([this.logProcesserLogicalId, permissionLogicalId])
+        .withDependsOn([ this.logProcesserLogicalId, permissionLogicalId ])
         .build();
 
       // Create subscription template
@@ -229,7 +229,7 @@ class ServerlessEsLogsPlugin {
             'Arn',
           ],
         })
-        .withDependsOn([this.logProcesserLogicalId, logGroupLogicalId])
+        .withDependsOn([ this.logProcesserLogicalId, logGroupLogicalId ])
         .build();
 
       // Create subscription filter
@@ -242,7 +242,7 @@ class ServerlessEsLogsPlugin {
         })
         .withFilterPattern(filterPattern)
         .withLogGroupName(logGroupName)
-        .withDependsOn([this.logProcesserLogicalId, permissionLogicalId])
+        .withDependsOn([ this.logProcesserLogicalId, permissionLogicalId ])
         .build();
 
       // Create subscription template

--- a/templates/code/logsToEs.js
+++ b/templates/code/logsToEs.js
@@ -5,6 +5,7 @@ var crypto = require('crypto');
 
 var endpoint = process.env.ES_ENDPOINT;
 var indexPrefix = process.env.ES_INDEX_PREFIX;
+var indexDateSeparator = process.env.ES_INDEX_DATE_SEPARATOR;
 var tags = undefined;
 try {
     tags = JSON.parse(process.env.ES_TAGS);
@@ -35,11 +36,11 @@ exports.handler = function(input, context) {
 
         // post documents to the Amazon Elasticsearch Service
         post(elasticsearchBulkPayload, function(error, success, statusCode, failedItems) {
-            console.log('Response: ' + JSON.stringify({ 
-                "statusCode": statusCode 
+            console.log('Response: ' + JSON.stringify({
+                "statusCode": statusCode
             }));
 
-            if (error) { 
+            if (error) {
                 console.log('Error: ' + JSON.stringify(error, null, 2));
 
                 if (failedItems && failedItems.length > 0) {
@@ -97,13 +98,14 @@ function transform(payload) {
 
     payload.logEvents.forEach(function(logEvent) {
         var timestamp = new Date(1 * logEvent.timestamp);
+        timestamp.utc
 
-        // index name format: cwl-YYYY.MM.DD
+        // index name format: indexPrefix-YYYY.MM.DD where '.' can be customized using indexDateSeparator
         var indexName = [
             indexPrefix + '-' + timestamp.getUTCFullYear(),   // year
             ('0' + (timestamp.getUTCMonth() + 1)).slice(-2),  // month
             ('0' + timestamp.getUTCDate()).slice(-2)          // day
-        ].join('.');
+        ].join(indexDateSeparator);
 
         var id = logEvent.id;
 
@@ -122,7 +124,7 @@ function transform(payload) {
         action.index._index = indexName;
         action.index._type = 'serverless-es-logs';
         action.index._id = id;
-        
+
         bulkRequest.push({ id, action, source });
     });
     return bulkRequest;
@@ -154,8 +156,8 @@ function buildSource(message, extractedFields) {
     }
 
     jsonSubString = extractJson(message);
-    if (jsonSubString !== null) { 
-        return JSON.parse(jsonSubString); 
+    if (jsonSubString !== null) {
+        return JSON.parse(jsonSubString);
     }
 
     return {};
@@ -191,13 +193,13 @@ function post(body, callback) {
             var info = JSON.parse(responseBody);
             var failedItems;
             var success;
-            
+
             if (response.statusCode >= 200 && response.statusCode < 299) {
                 failedItems = info.items.filter(function(x) {
                     return x.index.status >= 300;
                 });
 
-                success = { 
+                success = {
                     "attemptedItems": info.items.length,
                     "successfulItems": info.items.length - failedItems.length,
                     "failedItems": failedItems.length
@@ -227,13 +229,13 @@ function buildRequest(endpoint, body) {
     var kRegion = hmac(kDate, region);
     var kService = hmac(kRegion, service);
     var kSigning = hmac(kService, 'aws4_request');
-    
+
     var request = {
         host: endpoint,
         method: 'POST',
         path: '/_bulk',
         body: body,
-        headers: { 
+        headers: {
             'Content-Type': 'application/json',
             'Host': endpoint,
             'Content-Length': Buffer.byteLength(body),

--- a/templates/code/logsToEs.js
+++ b/templates/code/logsToEs.js
@@ -36,11 +36,11 @@ exports.handler = function(input, context) {
 
         // post documents to the Amazon Elasticsearch Service
         post(elasticsearchBulkPayload, function(error, success, statusCode, failedItems) {
-            console.log('Response: ' + JSON.stringify({
-                "statusCode": statusCode
+            console.log('Response: ' + JSON.stringify({ 
+                "statusCode": statusCode 
             }));
 
-            if (error) {
+            if (error) { 
                 console.log('Error: ' + JSON.stringify(error, null, 2));
 
                 if (failedItems && failedItems.length > 0) {
@@ -98,7 +98,6 @@ function transform(payload) {
 
     payload.logEvents.forEach(function(logEvent) {
         var timestamp = new Date(1 * logEvent.timestamp);
-        timestamp.utc
 
         // index name format: indexPrefix-YYYY.MM.DD where '.' can be customized using indexDateSeparator
         var indexName = [
@@ -124,7 +123,7 @@ function transform(payload) {
         action.index._index = indexName;
         action.index._type = 'serverless-es-logs';
         action.index._id = id;
-
+        
         bulkRequest.push({ id, action, source });
     });
     return bulkRequest;
@@ -156,8 +155,8 @@ function buildSource(message, extractedFields) {
     }
 
     jsonSubString = extractJson(message);
-    if (jsonSubString !== null) {
-        return JSON.parse(jsonSubString);
+    if (jsonSubString !== null) { 
+        return JSON.parse(jsonSubString); 
     }
 
     return {};
@@ -193,13 +192,13 @@ function post(body, callback) {
             var info = JSON.parse(responseBody);
             var failedItems;
             var success;
-
+            
             if (response.statusCode >= 200 && response.statusCode < 299) {
                 failedItems = info.items.filter(function(x) {
                     return x.index.status >= 300;
                 });
 
-                success = {
+                success = { 
                     "attemptedItems": info.items.length,
                     "successfulItems": info.items.length - failedItems.length,
                     "failedItems": failedItems.length
@@ -229,13 +228,13 @@ function buildRequest(endpoint, body) {
     var kRegion = hmac(kDate, region);
     var kService = hmac(kRegion, service);
     var kSigning = hmac(kService, 'aws4_request');
-
+    
     var request = {
         host: endpoint,
         method: 'POST',
         path: '/_bulk',
         body: body,
-        headers: {
+        headers: { 
             'Content-Type': 'application/json',
             'Host': endpoint,
             'Content-Length': Buffer.byteLength(body),

--- a/test/unit/plugin.test.ts
+++ b/test/unit/plugin.test.ts
@@ -47,7 +47,7 @@ describe('serverless-es-logs :: Plugin tests', () => {
         Type: 'AWS::Logs::LogGroup',
       };
     }
-    plugin = new ServerlessEsLogsPlugin(serverless, options);       
+    plugin = new ServerlessEsLogsPlugin(serverless, options);
   };
 
   describe('#hooks', () => {
@@ -69,7 +69,7 @@ describe('serverless-es-logs :: Plugin tests', () => {
             'ERROR: No configuration provided for serverless-es-logs!',
           );
         });
-  
+
         it('should throw an error if missing option \'endpoint\'', () => {
           const opts = {
             service: {
@@ -87,7 +87,7 @@ describe('serverless-es-logs :: Plugin tests', () => {
             'ERROR: Must define an endpoint for serverless-es-logs!',
           );
         });
-  
+
         it('should throw an error if missing option \'index\'', () => {
           const opts = {
             service: {
@@ -123,6 +123,26 @@ describe('serverless-es-logs :: Plugin tests', () => {
           expect(plugin.hooks['after:package:initialize']).to.throw(
             Error,
             "ERROR: Tags must be an object! You provided 'bad_tags'.",
+          );
+        });
+
+        it('should throw an error if \'indexDateSeparator\' is not a string', () => {
+          const opts = {
+            service: {
+              custom: {
+                esLogs: {
+                  index: 'some_index',
+                  indexDateSeparator: 100,
+                  endpoint: 'some_endpoint',
+                },
+              },
+            },
+          };
+          serverless = new ServerlessBuilder(opts).build();
+          plugin = new ServerlessEsLogsPlugin(serverless, options);
+          expect(plugin.hooks['after:package:initialize']).to.throw(
+            Error,
+            "ERROR: indexDateSeparator must be a string! You provided '100'.",
           );
         });
       });
@@ -270,11 +290,11 @@ describe('serverless-es-logs :: Plugin tests', () => {
               },
               {
                 Action: [
-                    "xray:PutTraceSegments",
-                    "xray:PutTelemetryRecords",
-                    "xray:GetSamplingRules",
-                    "xray:GetSamplingTargets",
-                    "xray:GetSamplingStatisticSummaries"
+                  "xray:PutTraceSegments",
+                  "xray:PutTelemetryRecords",
+                  "xray:GetSamplingRules",
+                  "xray:GetSamplingTargets",
+                  "xray:GetSamplingStatisticSummaries"
                 ],
                 Effect: "Allow",
                 Resource: "*"

--- a/test/unit/plugin.test.ts
+++ b/test/unit/plugin.test.ts
@@ -47,7 +47,7 @@ describe('serverless-es-logs :: Plugin tests', () => {
         Type: 'AWS::Logs::LogGroup',
       };
     }
-    plugin = new ServerlessEsLogsPlugin(serverless, options);
+    plugin = new ServerlessEsLogsPlugin(serverless, options);       
   };
 
   describe('#hooks', () => {
@@ -69,7 +69,7 @@ describe('serverless-es-logs :: Plugin tests', () => {
             'ERROR: No configuration provided for serverless-es-logs!',
           );
         });
-
+  
         it('should throw an error if missing option \'endpoint\'', () => {
           const opts = {
             service: {
@@ -87,7 +87,7 @@ describe('serverless-es-logs :: Plugin tests', () => {
             'ERROR: Must define an endpoint for serverless-es-logs!',
           );
         });
-
+  
         it('should throw an error if missing option \'index\'', () => {
           const opts = {
             service: {
@@ -125,26 +125,26 @@ describe('serverless-es-logs :: Plugin tests', () => {
             "ERROR: Tags must be an object! You provided 'bad_tags'.",
           );
         });
+      });
 
-        it('should throw an error if \'indexDateSeparator\' is not a string', () => {
-          const opts = {
-            service: {
-              custom: {
-                esLogs: {
-                  index: 'some_index',
-                  indexDateSeparator: 100,
-                  endpoint: 'some_endpoint',
-                },
+      it('should throw an error if \'indexDateSeparator\' is not a string', () => {
+        const opts = {
+          service: {
+            custom: {
+              esLogs: {
+                index: 'some_index',
+                indexDateSeparator: 100,
+                endpoint: 'some_endpoint',
               },
             },
-          };
-          serverless = new ServerlessBuilder(opts).build();
-          plugin = new ServerlessEsLogsPlugin(serverless, options);
-          expect(plugin.hooks['after:package:initialize']).to.throw(
-            Error,
-            "ERROR: indexDateSeparator must be a string! You provided '100'.",
-          );
-        });
+          },
+        };
+        serverless = new ServerlessBuilder(opts).build();
+        plugin = new ServerlessEsLogsPlugin(serverless, options);
+        expect(plugin.hooks['after:package:initialize']).to.throw(
+          Error,
+          "ERROR: indexDateSeparator must be a string! You provided '100'.",
+        );
       });
 
       describe('#addLogProcesser()', () => {
@@ -290,11 +290,11 @@ describe('serverless-es-logs :: Plugin tests', () => {
               },
               {
                 Action: [
-                  "xray:PutTraceSegments",
-                  "xray:PutTelemetryRecords",
-                  "xray:GetSamplingRules",
-                  "xray:GetSamplingTargets",
-                  "xray:GetSamplingStatisticSummaries"
+                    "xray:PutTraceSegments",
+                    "xray:PutTelemetryRecords",
+                    "xray:GetSamplingRules",
+                    "xray:GetSamplingTargets",
+                    "xray:GetSamplingStatisticSummaries"
                 ],
                 Effect: "Allow",
                 Resource: "*"


### PR DESCRIPTION
This PR allows the user to specify what separator they'd like to use with a default of the existing behavior being a period (`.`).

We currently use a separator of `-` for our Elasticsearch index. 
So it'll be `<index>-2020-04-20` instead of `<index>-2020.04.20`. 

Update the documentation as well added a test.
