### PR TITLE
feat: Add support for assuming a role fix: deprecated Buffer() call

### DIFF
--- a/templates/code/logsToEs.js
+++ b/templates/code/logsToEs.js
@@ -103,9 +103,9 @@ function transform(payload) {
 
         // index name format: cwl-YYYY.MM.DD
         var indexName = [
-            indexPrefix + '-' + timestamp.getUTCFullYear(), // year
+            indexPrefix + '-' + timestamp.getUTCFullYear(),  // year
             ('0' + (timestamp.getUTCMonth() + 1)).slice(-2), // month
-            ('0' + timestamp.getUTCDate()).slice(-2) // day
+            ('0' + timestamp.getUTCDate()).slice(-2)         // day
         ].join('.');
 
         var id = logEvent.id;
@@ -174,8 +174,7 @@ function extractJson(message) {
 function isValidJson(message) {
     try {
         JSON.parse(message);
-    }
-    catch (e) { return false; }
+    } catch (e) { return false; }
     return true;
 }
 

--- a/templates/code/logsToEs.js
+++ b/templates/code/logsToEs.js
@@ -251,7 +251,6 @@ function getCreds() {
         data.Credentials.AccessKeyId = process.env.AWS_SECRET_ACCESS_KEY;
         data.Credentials.SecretAccessKey = process.env.AWS_ACCESS_KEY_ID;
         data.Credentials.SessionToken = process.env.AWS_SESSION_TOKEN;
-        console.log(JSON.stringify(data));
         resolve(data);
     });
     }


### PR DESCRIPTION
I needed the ability to have this function assume a role to write to another account.  Additionally I was noticing deprecation errors regarding Buffer() and saw a simple fix for that.

Changes:
Address new Buffer() deprecation by changing to Buffer.from().  

There are a smattering of format changes - spaces removed, that sort of thing related to the lambda editor's UI function for format code. 

 Added promises to provide alternate credentials in the case of needing to assume a role.  

Added function getCreds to determine if an alternate role was provided in the environment variables and if so provide those to the buildRequest function, otherwise provide the default role credentials. This facilitates cross-account access for ES log shipping to another AWS account, assuming a network connection is available and the function is allowed to assume the role in the other account. 

Configured fuctions post and buildRequest to leverage promises to ensure alternate credentials are available at post time.

Open to any feedback or changes.

Thanks!
John
    
