### PR TITLE
chore(testing): Using new mocha configuration

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,5 @@
+recursive: true
+require:
+  - ts-node/register
+  - source-map-support/register
+spec: '**/*.test.ts'

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
---require ts-node/register
---require source-map-support/register
---recursive
-**/*.test.ts


### PR DESCRIPTION
Using new mocha configuration, legacy config is no longer supported by new mocha versions.