### PR TITLE
fix: Buffer() deprecation

### DIFF
--- a/templates/code/logsToEs.js
+++ b/templates/code/logsToEs.js
@@ -12,7 +12,7 @@ try {
 
 exports.handler = function(input, context) {
     // decode input from base64
-    var zippedInput = new Buffer(input.awslogs.data, 'base64');
+    var zippedInput = new Buffer.from(input.awslogs.data, 'base64');
 
     // decompress the input
     zlib.gunzip(zippedInput, function(error, buffer) {


### PR DESCRIPTION
fix: Use Buffer.from() instead of Buffer() which is deprecated

<!-- IMPORTANT: Please do not create a pull request without first creating an issue. See contributing guidelines -->
<!-- Changes should be discussed before opening a pull request. PRs without issues will be closed. -->

📖 **Description**
<!-- Briefly describe the changes you are making and why. -->
Fix deprecated Buffer() call.

✅ **Closes Issue**
<!-- Link back to the issue that this PR closes, ex: -->
closes: #424 
