### PR TITLE
feat(runtime): Use runtime from provider or default runtime if not provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -291,7 +291,7 @@ class ServerlessEsLogsPlugin {
         include: [`${this.logProcesserDir}/**`],
         individually: true,
       },
-      runtime: 'nodejs12.x',
+      runtime: this.serverless.service.provider.runtime ?? 'nodejs12.x',
       timeout: 60,
       tracing: false,
     };

--- a/test/unit/plugin.test.ts
+++ b/test/unit/plugin.test.ts
@@ -176,6 +176,56 @@ describe('serverless-es-logs :: Plugin tests', () => {
           plugin.hooks['after:package:initialize']();
           expect(serverless.service.functions.esLogsProcesser).to.have.deep.property('vpc', vpc);
         });
+
+        it('should use runtime from service if specified', () => {
+          const vpc = {
+            securityGroupIds: ['securityGroup'],
+            subnetIds: ['subnet']
+          };
+          const opts = {
+            service: {
+              provider: {
+                runtime: 'nodejs14.x'
+              },
+              custom: {
+                esLogs: {
+                  endpoint: 'some_endpoint',
+                  index: 'some_index',
+                  vpc
+                },
+              },
+            },
+          };
+          
+          serverless = new ServerlessBuilder(opts).build();
+          plugin = new ServerlessEsLogsPlugin(serverless, options);
+          plugin.hooks['after:package:initialize']();
+          expect(serverless.service.provider.runtime).to.equal('nodejs14.x');
+        });
+
+        it('should use default runtime if service does not specify runtime', () => {
+          const vpc = {
+            securityGroupIds: ['securityGroup'],
+            subnetIds: ['subnet']
+          };
+          const opts = {
+            service: {
+              custom: {
+                esLogs: {
+                  endpoint: 'some_endpoint',
+                  index: 'some_index',
+                  vpc
+                },
+              },
+            },
+          };
+          
+          serverless = new ServerlessBuilder(opts).build();
+          plugin = new ServerlessEsLogsPlugin(serverless, options);
+          plugin.hooks['after:package:initialize']();
+          expect(serverless.service.provider.runtime).to.equal('nodejs12.x');
+        });
+
       });
     });
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a pull request without first creating an issue. See contributing guidelines -->
<!-- Changes should be discussed before opening a pull request. PRs without issues will be closed. -->

📖 **Description**
<!-- Briefly describe the changes you are making and why. -->
This PR allows serverless-es-logs to use the provider runtime of your serverless service rather than the hard coded runtime in this plugin. 


✅ **Closes Issue**
<!-- Link back to the issue that this PR closes, ex: -->
<!-- closes: #534  -->
